### PR TITLE
NTUEEPLUS-108. Fix spelling mistake in 1808

### DIFF
--- a/backend/routes/srcs/in/column/preload/details/1808.js
+++ b/backend/routes/srcs/in/column/preload/details/1808.js
@@ -21,7 +21,7 @@ module.exports = {
   ],
   sections: [
     {
-      bigtittle: '一、跟求學時有關的問題',
+      bigtitle: '一、跟求學時有關的問題',
       sections: [
         {
           title: '談到電機系的歸屬感，請問對當年的電機系有什麼樣的回憶呢？',
@@ -41,7 +41,7 @@ module.exports = {
       ],
     },
     {
-      bigtittle: '二、跟從台大電機畢業時相關的問題',
+      bigtitle: '二、跟從台大電機畢業時相關的問題',
       sections: [
         {
           title: '教授是先在台大讀完 MS 才去北卡攻讀 Ph.D.，選擇這樣做，有什麼考量嗎？',
@@ -67,7 +67,7 @@ module.exports = {
       ],
     },
     {
-      bigtittle: '三、跟從事現在這個工作時有關的問題',
+      bigtitle: '三、跟從事現在這個工作時有關的問題',
       sections: [
         {
           title:


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.-->
bigtitle in 1808 is misspelled to bigtittle. This PR fix it 
### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]
Bug Fix
### Todos
* [ ] - no

### What is the Jira issue?
<!-- * Put Jira link here, and add [NTUEEPLUS-*Jira number*] in PR title, eg. `NTUEEPLUS-23. PR title`
-->
https://ntueeplus.atlassian.net/browse/NTUEEPLUS-108
### Screenshots (if appropriate)

