### PR TITLE
NTUEEPLUS-258. let imageEditor becomes more usable

### DIFF
--- a/client/src/views/auth/column/ColumnForm.js
+++ b/client/src/views/auth/column/ColumnForm.js
@@ -261,10 +261,19 @@ const ColumnForm = ({ data }) => {
           <ColumnImageEditor imgSrc={originalImage} />
         </CModalBody>
         <CModalFooter>
-          <CButton color="warning" onClick={clearImage}>
+          <CButton
+            color="warning"
+            onClick={clearImage}
+            style={{ display: croppedFile ? 'none' : 'block' }}
+          >
             Clear
           </CButton>
-          <CButton color="dark" onClick={saveEditImage} disabled={!croppedFile}>
+          <CButton
+            color="dark"
+            onClick={saveEditImage}
+            style={{ display: croppedFile ? 'block' : 'none' }}
+            disabled={!croppedFile}
+          >
             OK
           </CButton>
         </CModalFooter>

--- a/client/src/views/auth/column/ColumnImageEditor.js
+++ b/client/src/views/auth/column/ColumnImageEditor.js
@@ -35,6 +35,11 @@ const ColumnImageEditor = ({ imgSrc }) => {
     }
   }, [imgSrc, croppedAreaPixels])
 
+  const handleReturn = useCallback(() => {
+    dispatch(setCroppedFile(null))
+    dispatch(setCroppedDataUrl(''))
+  }, [dispatch])
+
   return (
     <>
       {croppedDataUrl === '' ? (
@@ -75,6 +80,11 @@ const ColumnImageEditor = ({ imgSrc }) => {
       ) : (
         <>
           <CImage src={croppedDataUrl} style={{ width: '90%' }} />
+          <CRow className="p-3">
+            <CButton onClick={handleReturn} color="secondary">
+              Return
+            </CButton>
+          </CRow>
         </>
       )}
     </>

--- a/client/src/views/auth/column/ColumnImageEditor.js
+++ b/client/src/views/auth/column/ColumnImageEditor.js
@@ -81,7 +81,7 @@ const ColumnImageEditor = ({ imgSrc }) => {
         <>
           <CImage src={croppedDataUrl} style={{ width: '90%' }} />
           <CRow className="p-3">
-            <CButton onClick={handleReturn} color="secondary">
+            <CButton onClick={handleReturn} color="secondary" style={{ width: '100px' }}>
               Return
             </CButton>
           </CRow>

--- a/client/src/views/components/CareerImageEditor.js
+++ b/client/src/views/components/CareerImageEditor.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { selectCareer, setCroppedFile, setCroppedDataUrl } from '../../../slices/careerSlice'
+import { selectCareer, setCroppedFile, setCroppedDataUrl } from '../../slices/careerSlice'
 import {
   CButton,
   CCol,
@@ -12,7 +12,7 @@ import {
   CInputGroup,
 } from '@coreui/react'
 import Cropper from 'react-easy-crop'
-import { getCroppedImg } from './'
+import { getCroppedImg } from '../in/career'
 
 const CareerImageEditor = ({ imgSrc }) => {
   const dispatch = useDispatch()

--- a/client/src/views/components/CareerImageEditor.js
+++ b/client/src/views/components/CareerImageEditor.js
@@ -35,6 +35,11 @@ const CareerImageEditor = ({ imgSrc }) => {
     }
   }, [imgSrc, croppedAreaPixels])
 
+  const handleReturn = useCallback(() => {
+    dispatch(setCroppedFile(null))
+    dispatch(setCroppedDataUrl(''))
+  }, [dispatch])
+
   return (
     <>
       {croppedDataUrl === '' ? (
@@ -75,6 +80,11 @@ const CareerImageEditor = ({ imgSrc }) => {
       ) : (
         <>
           <CImage src={croppedDataUrl} style={{ width: '90%' }} />
+          <CRow className="p-3">
+            <CButton onClick={handleReturn} color="secondary">
+              Return
+            </CButton>
+          </CRow>
         </>
       )}
     </>

--- a/client/src/views/components/CareerImageEditor.js
+++ b/client/src/views/components/CareerImageEditor.js
@@ -81,7 +81,7 @@ const CareerImageEditor = ({ imgSrc }) => {
         <>
           <CImage src={croppedDataUrl} style={{ width: '90%' }} />
           <CRow className="p-3">
-            <CButton onClick={handleReturn} color="secondary">
+            <CButton onClick={handleReturn} color="secondary" style={{ width: '100px' }}>
               Return
             </CButton>
           </CRow>

--- a/client/src/views/in/recommendation/RecommendationForm.js
+++ b/client/src/views/in/recommendation/RecommendationForm.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { selectLogin } from '../../../slices/loginSlice'
 import { selectCareer, clearCroppedDataUrl, clearCroppedFile } from '../../../slices/careerSlice'
 import { useHistory } from 'react-router'
-import CareerImageEditor from '../career/CareerImageEditor'
+import CareerImageEditor from '../../components/CareerImageEditor'
 import ReactTooltip from 'react-tooltip'
 import PropTypes from 'prop-types'
 import {
@@ -190,10 +190,19 @@ const RecommendationForm = ({ data }) => {
           <CareerImageEditor imgSrc={originalImage} />
         </CModalBody>
         <CModalFooter>
-          <CButton color="warning" onClick={clearImage}>
+          <CButton
+            color="warning"
+            onClick={clearImage}
+            style={{ display: croppedFile ? 'none' : 'block' }}
+          >
             Clear
           </CButton>
-          <CButton color="dark" onClick={saveEditImage} disabled={!croppedFile}>
+          <CButton
+            color="dark"
+            onClick={saveEditImage}
+            style={{ display: croppedFile ? 'block' : 'none' }}
+            disabled={!croppedFile}
+          >
             OK
           </CButton>
         </CModalFooter>

--- a/client/src/views/in/recruitment/RecruitmentForm.js
+++ b/client/src/views/in/recruitment/RecruitmentForm.js
@@ -3,7 +3,7 @@ import React, { useState, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { selectCareer, clearCroppedDataUrl, clearCroppedFile } from '../../../slices/careerSlice'
 import { useHistory } from 'react-router'
-import CareerImageEditor from '../career/CareerImageEditor'
+import CareerImageEditor from '../../components/CareerImageEditor'
 import JoditEditor from 'jodit-react'
 import ReactTooltip from 'react-tooltip'
 import PropTypes from 'prop-types'
@@ -192,10 +192,19 @@ const CareerForm = ({ data }) => {
           <CareerImageEditor imgSrc={originalImage} />
         </CModalBody>
         <CModalFooter>
-          <CButton color="warning" onClick={clearImage}>
+          <CButton
+            color="warning"
+            onClick={clearImage}
+            style={{ display: croppedFile ? 'none' : 'block' }}
+          >
             Clear
           </CButton>
-          <CButton color="dark" onClick={saveEditImage} disabled={!croppedFile}>
+          <CButton
+            color="dark"
+            onClick={saveEditImage}
+            style={{ display: croppedFile ? 'block' : 'none' }}
+            disabled={!croppedFile}
+          >
             OK
           </CButton>
         </CModalFooter>


### PR DESCRIPTION
### What is this PR for?
Before user click “show result”, “ok” shouldn’t appear.
Adding a "Return" button after clicking the "show result" button, so that users can edit the same photo without uploading it again.

### What type of PR is it?
Improvement

### Todos
none

### What is the Jira issue?
[NTUEEPLUS-258](https://ntueeplus.atlassian.net/browse/NTUEEPLUS-258). let imageEditor becomes more usable

### Screenshots (if appropriate)
1.Choose an image.
<img width="1018" alt="截圖 2023-03-02 下午5 43 53" src="https://user-images.githubusercontent.com/70316322/222392536-f742f9f6-b874-4912-839b-13a2fd3fb622.png">

2.Preview of the cropped image, and the Return button for cropping the same image again.
<img width="1151" alt="截圖 2023-03-09 下午8 16 44" src="https://user-images.githubusercontent.com/70316322/224022022-3a68e9ff-2f8f-4c81-a86f-1dfe0ddf2d17.png">







[NTUEEPLUS-258]: https://ntueeplus.atlassian.net/browse/NTUEEPLUS-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ