### PR TITLE
NTUEEPLUS-280. more usable text editor for posting recruitments and columns

### DIFF
--- a/client/src/views/auth/column/ColumnPreview.js
+++ b/client/src/views/auth/column/ColumnPreview.js
@@ -92,8 +92,8 @@ const ColumnPreview = ({ post, annotation, title, body, anno, exp, edu, intro })
                 {subtitle(body.bigtitle)}
                 {body.bigsections.map((bigsection, sectionIdx) => (
                   <div key={sectionIdx}>
-                    {section(bigsection.subtitle)}
-                    {content(bigsection.subsection)}
+                    <h3>{bigsection.subtitle}</h3>
+                    <p style={{ whiteSpace: 'pre' }}>{bigsection.subsection}</p>
                   </div>
                 ))}
               </div>

--- a/client/src/views/auth/column/ColumnPreview.js
+++ b/client/src/views/auth/column/ColumnPreview.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { CButton, CWidgetBrand } from '@coreui/react'
 import { Column_Background } from './index'
+import { eesa } from './index'
 
 const ColumnPreview = ({ post, annotation, title, body, anno, exp, edu, intro }) => {
   const [isExpand, setIsExpand] = useState(false)
@@ -93,7 +94,7 @@ const ColumnPreview = ({ post, annotation, title, body, anno, exp, edu, intro })
                 {body.bigsections.map((bigsection, sectionIdx) => (
                   <div key={sectionIdx}>
                     <h3>{bigsection.subtitle}</h3>
-                    <p style={{ whiteSpace: 'pre' }}>{bigsection.subsection}</p>
+                    <FormattedText text={bigsection.subsection} />
                   </div>
                 ))}
               </div>

--- a/client/src/views/components/FormattedText.js
+++ b/client/src/views/components/FormattedText.js
@@ -1,8 +1,11 @@
 import React from 'react'
 import parser from 'html-react-parser'
-import { urlsToLinks } from '../in/career/index'
 const FormattedText = ({ text }) => {
-  const transformedText = parser(urlsToLinks(text))
-  return <h5 style={{ whiteSpace: 'pre-wrap' }}>{transformedText}</h5>
+  const transformedText = urlsToLinks(text)
+  return <h5 style={{ whiteSpace: 'pre-wrap' }}>{parser(transformedText)}</h5>
 }
 export default FormattedText
+const urlsToLinks = (text) => {
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  return text.replace(urlRegex, '<a href="$1">$1</a>')
+}

--- a/client/src/views/components/FormattedText.js
+++ b/client/src/views/components/FormattedText.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import parser from 'html-react-parser'
+import { urlsToLinks } from '../in/career/index'
+const FormattedText = ({ text }) => {
+  const transformedText = parser(urlsToLinks(text))
+  return <h5 style={{ whiteSpace: 'pre-wrap' }}>{transformedText}</h5>
+}
+export default FormattedText

--- a/client/src/views/in/career/CareerBlock.js
+++ b/client/src/views/in/career/CareerBlock.js
@@ -5,8 +5,7 @@ import { CButton, CAvatar } from '@coreui/react'
 import { eesa } from './index'
 import CIcon from '@coreui/icons-react'
 import axios from 'axios'
-import parser from 'html-react-parser'
-import { urlsToLinks } from './index'
+import FormattedText from '../../components/FormattedText'
 
 const CareerBlock = ({ post, isAuth }) => {
   const location = useLocation()
@@ -129,9 +128,7 @@ const CareerBlock = ({ post, isAuth }) => {
                 {post.spec.description && (
                   <>
                     <h4 style={{ fontWeight: '600', margin: '1rem 0 0.1rem' }}>說明：</h4>
-                    <h5 style={{ whiteSpace: 'pre' }}>
-                      {parser(urlsToLinks(post.spec.description))}
-                    </h5>
+                    <FormattedText text={post.spec.description} />
                   </>
                 )}
                 <button onClick={() => setIsExpand(false)}>Show less...</button>

--- a/client/src/views/in/career/CareerBlock.js
+++ b/client/src/views/in/career/CareerBlock.js
@@ -129,7 +129,9 @@ const CareerBlock = ({ post, isAuth }) => {
                 {post.spec.description && (
                   <>
                     <h4 style={{ fontWeight: '600', margin: '1rem 0 0.1rem' }}>說明：</h4>
-                    <h5>{parser(urlsToLinks(post.spec.description))}</h5>
+                    <h5 style={{ whiteSpace: 'pre-line' }}>
+                      {parser(urlsToLinks(post.spec.description))}
+                    </h5>
                   </>
                 )}
                 <button onClick={() => setIsExpand(false)}>Show less...</button>

--- a/client/src/views/in/career/CareerBlock.js
+++ b/client/src/views/in/career/CareerBlock.js
@@ -2,10 +2,9 @@ import React, { useState } from 'react'
 import { Link, useLocation, useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { CButton, CAvatar } from '@coreui/react'
-import { eesa } from './index'
+import { eesa, FormattedText } from './index'
 import CIcon from '@coreui/icons-react'
 import axios from 'axios'
-import FormattedText from '../../components/FormattedText'
 
 const CareerBlock = ({ post, isAuth }) => {
   const location = useLocation()

--- a/client/src/views/in/career/CareerBlock.js
+++ b/client/src/views/in/career/CareerBlock.js
@@ -129,7 +129,7 @@ const CareerBlock = ({ post, isAuth }) => {
                 {post.spec.description && (
                   <>
                     <h4 style={{ fontWeight: '600', margin: '1rem 0 0.1rem' }}>說明：</h4>
-                    <h5 style={{ whiteSpace: 'pre-line' }}>
+                    <h5 style={{ whiteSpace: 'pre' }}>
                       {parser(urlsToLinks(post.spec.description))}
                     </h5>
                   </>

--- a/client/src/views/in/career/CareerPreview.js
+++ b/client/src/views/in/career/CareerPreview.js
@@ -77,9 +77,7 @@ const CareerPreview = ({ post, experience, requirement, resumeURL }) => {
               {post.description && (
                 <>
                   <h4 style={{ fontWeight: '600', margin: '1.3rem 0 0.1rem' }}>說明：</h4>
-                  <h5 style={{ whiteSpace: 'pre-line' }}>
-                    {parser(urlsToLinks(post.description))}
-                  </h5>
+                  <h5 style={{ whiteSpace: 'pre' }}>{parser(urlsToLinks(post.description))}</h5>
                 </>
               )}
               <button onClick={() => setIsExpand(false)}>Show less...</button>

--- a/client/src/views/in/career/CareerPreview.js
+++ b/client/src/views/in/career/CareerPreview.js
@@ -77,7 +77,9 @@ const CareerPreview = ({ post, experience, requirement, resumeURL }) => {
               {post.description && (
                 <>
                   <h4 style={{ fontWeight: '600', margin: '1.3rem 0 0.1rem' }}>說明：</h4>
-                  <h5>{parser(urlsToLinks(post.description))}</h5>
+                  <h5 style={{ whiteSpace: 'pre-line' }}>
+                    {parser(urlsToLinks(post.description))}
+                  </h5>
                 </>
               )}
               <button onClick={() => setIsExpand(false)}>Show less...</button>

--- a/client/src/views/in/career/CareerPreview.js
+++ b/client/src/views/in/career/CareerPreview.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { CButton } from '@coreui/react'
-import { eesa } from './index'
-import FormattedText from '../../components/FormattedText'
+import { eesa, FormattedText } from './index'
 const CareerPreview = ({ post, experience, requirement, resumeURL }) => {
   const [isExpand, setIsExpand] = useState(false)
   const [previewURL, setPreviewURL] = useState(post.file)

--- a/client/src/views/in/career/CareerPreview.js
+++ b/client/src/views/in/career/CareerPreview.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { CButton } from '@coreui/react'
 import { eesa } from './index'
-import parser from 'html-react-parser'
-import { urlsToLinks } from './index'
-
+import FormattedText from '../../components/FormattedText'
 const CareerPreview = ({ post, experience, requirement, resumeURL }) => {
   const [isExpand, setIsExpand] = useState(false)
   const [previewURL, setPreviewURL] = useState(post.file)
@@ -77,7 +75,7 @@ const CareerPreview = ({ post, experience, requirement, resumeURL }) => {
               {post.description && (
                 <>
                   <h4 style={{ fontWeight: '600', margin: '1.3rem 0 0.1rem' }}>說明：</h4>
-                  <h5 style={{ whiteSpace: 'pre' }}>{parser(urlsToLinks(post.description))}</h5>
+                  <FormattedText text={post.description} />
                 </>
               )}
               <button onClick={() => setIsExpand(false)}>Show less...</button>

--- a/client/src/views/in/career/index.js
+++ b/client/src/views/in/career/index.js
@@ -3,7 +3,16 @@ import { selectCareer, setKeywords, clearKeywords } from '../../../slices/career
 import eesa from '../../../assets/images/eesa-icon.png'
 import Recruitment_image from '../../../assets/images/Recruitment.png'
 import Recommendation_image from '../../../assets/images/Recommendation.png'
-export { selectCareer, setKeywords, clearKeywords, eesa, Recommendation_image, Recruitment_image }
+import FormattedText from '../../components/FormattedText'
+export {
+  selectCareer,
+  setKeywords,
+  clearKeywords,
+  eesa,
+  Recommendation_image,
+  Recruitment_image,
+  FormattedText,
+}
 export default Career
 
 const createImage = (url) =>

--- a/client/src/views/in/column/Resume.js
+++ b/client/src/views/in/column/Resume.js
@@ -6,7 +6,7 @@ const Resume = ({ data }) => {
       return (
         <div key={bigsection.subtitle}>
           <h3>{bigsection.subtitle}</h3>
-          <p>&emsp;&emsp;&thinsp;&thinsp;{bigsection.subsection}</p>
+          <p style={{ whiteSpace: 'pre' }}>{bigsection.subsection}</p>
         </div>
       )
     })

--- a/client/src/views/in/column/Resume.js
+++ b/client/src/views/in/column/Resume.js
@@ -1,12 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
+import FormattedText from '../../components/FormattedText'
 const Resume = ({ data }) => {
   const getSubSections = (bigsection) => {
     const subSections = bigsection.bigsections.map((bigsection) => {
       return (
         <div key={bigsection.subtitle}>
           <h3>{bigsection.subtitle}</h3>
-          <p style={{ whiteSpace: 'pre' }}>{bigsection.subsection}</p>
+          <FormattedText text={bigsection.subsection} />
         </div>
       )
     })

--- a/client/src/views/in/column/Resume.js
+++ b/client/src/views/in/column/Resume.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
-import FormattedText from '../../components/FormattedText'
+import { FormattedText } from './index'
 const Resume = ({ data }) => {
   const getSubSections = (bigsection) => {
     const subSections = bigsection.bigsections.map((bigsection) => {

--- a/client/src/views/in/column/index.js
+++ b/client/src/views/in/column/index.js
@@ -1,4 +1,5 @@
 import Column from './Column'
 import Spinner from '../../components/Spinner'
+import FormattedText from '../../components/FormattedText'
 export default Column
-export { Spinner }
+export { Spinner, FormattedText }

--- a/client/src/views/in/matching/matchForm/MatchForm.js
+++ b/client/src/views/in/matching/matchForm/MatchForm.js
@@ -96,7 +96,8 @@ const MatchForm = () => {
     }
   }
   const handleInputArray = (e) => {
-    setDataForm({ ...dataForm, [e.target.name]: e.target.value })
+    const a = strToArray(e.target.value)
+    setDataForm({ ...dataForm, [e.target.name]: a })
     if (requiredStyle.hasOwnProperty(e.target.name)) {
       if (e.target.value === '')
         setRequiredStyle({ ...requiredStyle, [e.target.name]: 'border-3 border-danger' })
@@ -122,8 +123,6 @@ const MatchForm = () => {
       alert('please fill in correct gpa')
       return
     }
-    const a = strToArray(dataForm.admission)
-    setDataForm({ ...dataForm, admission: a })
     axios
       .post('/api/study/fillForm', dataForm)
       .then(() => {
@@ -138,7 +137,7 @@ const MatchForm = () => {
     await axios
       .get('/api/study/form')
       .then((res) => {
-        const { degree: deg, hasPaper: hp, endTime: et } = res.data
+        const { degree: deg, hasPaper: hpaper, endTime: et } = res.data
         if (et) {
           const [year, month, day, h_m] = et.split('-')
           const [hour, min] = h_m.split(':')
@@ -151,8 +150,8 @@ const MatchForm = () => {
           degs[degg] = true
           setDegrees(degs)
         }
-        if (hp) {
-          const hp = Number(hp)
+        if (hpaper) {
+          const hp = Number(hpaper)
           let hps = Array(4).fill(false)
           hps[hp] = true
           setHasPapers(hps)


### PR DESCRIPTION
### What is this PR for?
Add FormattedText in components, so that text can have indent and new line just like user-inputted indentations and new lines. Description in Recruitments and sections in Columns has already changed to FormattedText.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://ntueeplus.atlassian.net/browse/NTUEEPLUS-280

### Screenshots (if appropriate)
1. Columns: The text have indents and can change to new line.
<img width="1036" alt="截圖 2023-07-03 上午1 58 02" src="https://github.com/NTUEE-PLUS/EndOfWeb/assets/70316322/ca3da21f-a776-4ebd-af76-c93452551a15">

2. Recruitments: Text have indents and empty lines. Also, url will automatically turn to links.
<img width="1020" alt="截圖 2023-07-03 上午1 56 57" src="https://github.com/NTUEE-PLUS/EndOfWeb/assets/70316322/143d2bbe-3d87-403d-8f2c-cbb5622abfca">

